### PR TITLE
make the character in ** to bold

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -43,6 +43,10 @@ pre
     tab-size: 2;
 }
 
+strong
+{
+    font-weight: bold;
+}
 
 .hljs {
     white-space: pre;


### PR DESCRIPTION
Hi ! 
I like `hyde-hyde` theme very  much. Thank you so much for making.

Would you like to support bold about `**` syntax ?

![1](https://user-images.githubusercontent.com/9004827/40049574-1bb7b114-5870-11e8-9037-5e7aa86f9968.png)

Dosen't this need because of there is no code in poole.css ?