### PR TITLE
Fix problem of themeColor configuration

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
     {{ block "header" . -}}{{- end }}
-    <body {{- if .Site.Params.themeColor }}class="{{ .Site.Params.themeColor }} {{if .Site.Params.layoutReverse}}layout-reverse{{ end }}"{{end}}>
+    <body {{ if .Site.Params.themeColor }}class="{{ .Site.Params.themeColor }} {{if .Site.Params.layoutReverse}}layout-reverse{{ end }}"{{end}}>
         {{ partial "sidebar.html" . -}}
         <div class="content container">
             {{ block "content" . -}}{{- end }}


### PR DESCRIPTION
Hi,  I like this theme! 

I tried to configure themeColor option which is supported by hyde, but nothing has changed on my website. 

The generated HTML is like below;

```
<bodyclass="theme-base-08 ">
```

There is no space between body and class. I think the hyphen next to body tag is unnecessary. What do you think of it?