### PR TITLE
Changed styles definition to use relative URLs

### DIFF
--- a/layouts/partials/header/styles-highlight.html
+++ b/layouts/partials/header/styles-highlight.html
@@ -4,5 +4,5 @@
 {{ end }}
 {{ if .Site.Params.PygmentsUseClasses }}
 <!-- Pygments Syntax -->
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/syntax.min.css">
+<link rel="stylesheet" href="css/syntax.min.css">
 {{ end }}

--- a/layouts/partials/header/styles.html
+++ b/layouts/partials/header/styles.html
@@ -1,3 +1,3 @@
 {{ partial "header/styles-highlight.html" . }}
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/hyde-hyde.css">
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/print.min.css" media="print">
+<link rel="stylesheet" href="css/hyde-hyde.css">
+<link rel="stylesheet" href="css/print.min.css" media="print">


### PR DESCRIPTION
Thanks for the work on the theme.

I generally create Hugo sites through the Blogdown package for R/RStudio.

When creating a Hugo site with Blogdown, I ran into some issues with the CSS not being referenced correctly. The team that maintains Blogdown had these suggestions: https://github.com/rstudio/blogdown/issues/319. According to them, omitting `{{.Site.BaseURL}}` is the correct way to specify relative URLs. 

I should also note that if someone is creating a Github Pages project site, as opposed to a personal site, and they incorrectly specify their base URL in config.toml/config.yaml, the styles as referenced will also not be correctly referenced.