### PR TITLE
Fix css URL

### DIFF
--- a/layouts/partials/header/styles-highlight.html
+++ b/layouts/partials/header/styles-highlight.html
@@ -4,5 +4,5 @@
 {{ end }}
 {{ if .Site.Params.PygmentsUseClasses }}
 <!-- Pygments Syntax -->
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/syntax.min.css">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.min.css">
 {{ end }}

--- a/layouts/partials/header/styles.html
+++ b/layouts/partials/header/styles.html
@@ -1,3 +1,3 @@
 {{ partial "header/styles-highlight.html" . }}
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/hyde-hyde.css">
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/print.min.css" media="print">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}css/hyde-hyde.css">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}css/print.min.css" media="print">


### PR DESCRIPTION
This commit shall remove the unnecessary  slash appeared in the generated html files.

We can reproduce the "double slash" with the following config:
`baseurl = "http://localhost/"`
and run following commands
```
hugo
cd public
cat 404.html | grep '\/\/css'
# <link rel="stylesheet" href="http://localhost//css/hyde-hyde.css">
```
