### PR TITLE
Moved title setting outside of params

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,7 @@
 baseurl = "https://example.com/"
 languageCode = "en"
 
+title = "Title"
 theme = "hyde-hyde"
 
 ## Hugo Built-in Features


### PR DESCRIPTION
This is a PR for the config.toml in the example site content.

For some reason, it seems that having `title` in the `[Params]` section doesn't get picked up by Hugo, so I suggest moving it. It seems that your own personal site follows this `config.toml` structure already (https://github.com/htr3n/htr3n-blog/blob/master/config.toml)

I was also curious if the `copyright` value is currently used anywhere in the theme? In your personal site, it's listed in the `config.toml`, but I can't seem to find it displayed anywhere on your live site.