### PR TITLE
Fix author image URL

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,7 +7,7 @@
       </span>
       {{ with .Site.Params.authorimage }}
       {{ $strippedSlash := ($.Site.Params.authorimage | replaceRE "^(/)+(.*)" "$2") }}
-      {{ $authorImage := (printf "%s%s" $.Site.BaseURL $strippedSlash) }}
+      {{ $authorImage := (printf "%s/%s" $.Site.BaseURL $strippedSlash) }}
       <div class="author-image">
         <img src="{{$authorImage}}" alt="Author Image" class="img--circle img--headshot element--center"> 
       </div>


### PR DESCRIPTION
With an authorImage like `/images/me.png`, the authorImage URL was created like `http://example.comimages/me.png`
missing a slash in between the base URL and the image.

This adds the missing slash.