### PR TITLE
Adds XFN rel-me links

### DIFF
--- a/layouts/partials/sidebar/social.html
+++ b/layouts/partials/sidebar/social.html
@@ -1,41 +1,41 @@
 <section class="social">
 	{{ with .Site.Params.social.twitter }}
-	<a href="https://twitter.com/{{.}}"><i class="fab fa-twitter fa-lg" aria-hidden="true"></i></a>
+	<a href="https://twitter.com/{{.}}" rel="me"><i class="fab fa-twitter fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.facebook }}
-	&nbsp;<a href="https://facebook.com/{{.}}"><i class="fab fa-facebook-f"></i></a>
+	&nbsp;<a href="https://facebook.com/{{.}}" rel="me"><i class="fab fa-facebook-f"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.github }}
-	&nbsp;<a href="https://github.com/{{.}}"><i class="fab fa-github fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://github.com/{{.}}" rel="me"><i class="fab fa-github fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.bitbucket }}
-	&nbsp;<a href="https://bitbucket.org/{{.}}"><i class="fab fa-bitbucket fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://bitbucket.org/{{.}}" rel="me"><i class="fab fa-bitbucket fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.gitlab }}
-	&nbsp;<a href="https://gitlab.com/{{.}}"><i class="fab fa-gitlab fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://gitlab.com/{{.}}" rel="me"><i class="fab fa-gitlab fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.instagram }}
-	&nbsp;<a href="https://instagram.com/{{.}}"><i class="fab fa-instagram fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://instagram.com/{{.}}" rel="me"><i class="fab fa-instagram fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.linkedin }}
-	&nbsp;<a href="https://linkedin.com/in/{{.}}"><i class="fab fa-linkedin fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://linkedin.com/in/{{.}}" rel="me"><i class="fab fa-linkedin fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.stackoverflow }}
-	&nbsp;<a href="https://stackoverflow.com/users/{{.}}"><i class="fab fa-stack-overflow fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://stackoverflow.com/users/{{.}}" rel="me"><i class="fab fa-stack-overflow fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.medium}}
-	&nbsp;<a href="https://medium.com/@{{.}}"><i class="fab fa-medium fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://medium.com/@{{.}}" rel="me"><i class="fab fa-medium fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.xing }}
-	&nbsp;<a href="https://www.xing.com/profile/{{.}}"><i class="fab fa-xing fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://www.xing.com/profile/{{.}}" rel="me"><i class="fab fa-xing fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.keybase }}
-	&nbsp;<a href="https://keybase.io/{{.}}"><i class="fab fa-keybase fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://keybase.io/{{.}}" rel="me"><i class="fab fa-keybase fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.telegram }}
-	&nbsp;<a href="https://t.me/{{.}}"><i class="fab fa-telegram fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="https://t.me/{{.}}" rel="me"><i class="fab fa-telegram fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.email }}
-	&nbsp;<a href="mailto:{{.}}"><i class="fas fa-at fa-lg" aria-hidden="true"></i></a>
+	&nbsp;<a href="mailto:{{.}}" rel="me"><i class="fas fa-at fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 </section>


### PR DESCRIPTION
Supports [rel-me](http://microformats.org/wiki/rel-me), a commonly used microformat for linking disparate social profiles together. This enables the use of [IndieAuth](https://indieauth.com/) for login on other websites.