### PR TITLE
Remove erroneous '+' sign

### DIFF
--- a/layouts/partials/header/styles-highlight.html
+++ b/layouts/partials/header/styles-highlight.html
@@ -6,5 +6,5 @@
 {{ end }}
 {{ if .Site.Params.PygmentsUseClasses }}
 <!-- Pygments Syntax -->
-+<link rel="stylesheet" href="{{ "css/syntax.min.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/syntax.min.css" | relURL }}">
 {{ end }}


### PR DESCRIPTION
There is a '+' sign left in one of the header partials, it becomes visible on mobile. 