### PR TITLE
Fixed mobile header clickable area to be full width

### DIFF
--- a/assets/scss/hyde-hyde/_responsive.scss
+++ b/assets/scss/hyde-hyde/_responsive.scss
@@ -10,6 +10,10 @@
     li {
       padding: .1rem 0;
     }
+    .container {
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
   .hidden-tablet {
     display: none;
@@ -42,6 +46,7 @@
     cursor: pointer; }
   .collapsible-menu label {
     background: url(/img/menu-open.svg) no-repeat left center;
+    background-position: 1.5rem;
     display: block;
     cursor: pointer;
     color: #fff;
@@ -55,7 +60,8 @@
   }
 
   input#menuToggle:checked + label {
-    background-image: url(/img/menu-close.svg); 
+    background-image: url(/img/menu-close.svg);
+    background-position: 1.5rem; 
     color: #fff;
   }
   


### PR DESCRIPTION
On mobile the header clickable area is not the full width of header so you can see the padding on the sides when it is tapped. 
This resolves that by removing the padding on the sidebar container and offsetting the background image, the visual results are identical but now the clickable area is the full header.