### PR TITLE
Add gravatar support

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -5,14 +5,16 @@
       <span class="site__title">
         <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
       </span>
-      {{ with .Site.Params.authorimage }}
-      {{ $strippedSlash := ($.Site.Params.authorimage | replaceRE "^(/)+(.*)" "$2") }}
-      {{ $authorImage := (printf "%s/%s" $.Site.BaseURL $strippedSlash) }}
-      <div class="author-image">
-        <img src="{{$authorImage}}" alt="Author Image" class="img--circle img--headshot element--center">
-      </div>
+      {{ if and (isset .Site.Params "authorimage") (not (isset .Site.Params.social "gravatar")) }}
+        {{ with .Site.Params.authorimage }}
+        {{ $strippedSlash := ($.Site.Params.authorimage | replaceRE "^(/)+(.*)" "$2") }}
+        {{ $authorImage := (printf "%s/%s" $.Site.BaseURL $strippedSlash) }}
+        <div class="author-image">
+          <img src="{{$authorImage}}" alt="Author Image" class="img--circle img--headshot element--center">
+        </div>
+        {{ end }}
       {{ end }}
-      {{ with .Site.Params.social.email}}
+      {{ with .Site.Params.social.gravatar}}
         <div class="author-image">
           <img src="https://www.gravatar.com/avatar/{{md5 .}}?s=240&d=mp" class="img--circle img--headshot element--center" alt="gravatar">
         </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -12,6 +12,11 @@
         <img src="{{$authorImage}}" alt="Author Image" class="img--circle img--headshot element--center">
       </div>
       {{ end }}
+      {{ with .Site.Params.social.email}}
+        <div class="author-image">
+          <img src="https://www.gravatar.com/avatar/{{md5 .}}?s=240&d=mp" class="img--circle img--headshot element--center" alt="gravatar">
+        </div>
+      {{ end }}
       <p class="site__description">
         {{ with .Site.Params.description }} {{.}} {{end}}
       </p>


### PR DESCRIPTION
Not sure if it fits theme design however I find it extremely useful to have gravatar support so there is no need to store images in the static folder. A previous option is still supported if `authorimage` has been provided. 

Also, not sure if they have to be mutual exclusive.