### PR TITLE
reverse PR that added additional slash to `authorimage` file path

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -8,7 +8,7 @@
       {{ if and (isset .Site.Params "authorimage") (not (isset .Site.Params.social "gravatar")) }}
         {{ with .Site.Params.authorimage }}
         {{ $strippedSlash := ($.Site.Params.authorimage | replaceRE "^(/)+(.*)" "$2") }}
-        {{ $authorImage := (printf "%s/%s" $.Site.BaseURL $strippedSlash) }}
+        {{ $authorImage := (printf "%s%s" $.Site.BaseURL $strippedSlash) }}
         <div class="author-image">
           <img src="{{$authorImage}}" alt="Author Image" class="img--circle img--headshot element--center">
         </div>

--- a/layouts/partials/sidebar/about.html
+++ b/layouts/partials/sidebar/about.html
@@ -4,7 +4,7 @@
   </span>
   {{ with .Site.Params.authorimage }}
   {{ $strippedSlash := ($.Site.Params.authorimage | replaceRE "^(/)+(.*)" "$2") }}
-  {{ $authorImage := (printf "%s/%s" $.Site.BaseURL $strippedSlash) }}
+  {{ $authorImage := (printf "%s%s" $.Site.BaseURL $strippedSlash) }}
   <div class="author-image">
     <img src="{{$authorImage}}" alt="Author Image" class="img--circle img--headshot element--center">
   </div>


### PR DESCRIPTION
The change in PR https://github.com/htr3n/hyde-hyde/pull/37 made it so that there were two slashes instead of one, such that the `authorimage` from the exampleSite would not render.

<img width="1134" alt="screen shot 2018-12-13 at 8 28 07 pm" src="https://user-images.githubusercontent.com/12160301/50017048-d5efeb80-ff7f-11e8-827c-d3f2c9fae6a0.png">

This PR returns the original code for rendering the `authorimage`, which works with the following `config.toml` settings:

```
[params]
    authorimage = "img/hugo.png"
```

or

```
[params]
    authorimage = "/img/hugo.png"
```

Both work, such that the `authorimage` appears in the sidebar across the full site, and now the exampleSite `hugo.png` shows up. I am running Hugo 0.52, and using the theme via the R blogdown package. I am unable to replicate the error cited in the original PR.

<img width="1140" alt="screen shot 2018-12-13 at 8 29 14 pm" src="https://user-images.githubusercontent.com/12160301/50017232-65959a00-ff80-11e8-83ef-b4da26260c77.png">

