### PR TITLE
Custom gitlab domains

### DIFF
--- a/layouts/partials/sidebar/social.html
+++ b/layouts/partials/sidebar/social.html
@@ -11,8 +11,12 @@
 	{{ with .Site.Params.social.bitbucket }}
 	<a href="https://bitbucket.org/{{.}}" rel="me"><i class="fab fa-bitbucket fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
+	{{ $gitlab_domain := "gitlab.com" }}
+	{{ with .Site.Params.social.custom_gitlab_domain }}
+		{{ $gitlab_domain = . }}
+	{{ end }}
 	{{ with .Site.Params.social.gitlab }}
-	<a href="https://gitlab.com/{{.}}" rel="me"><i class="fab fa-gitlab fa-lg" aria-hidden="true"></i></a>
+	<a href="https://{{ $gitlab_domain }}/{{.}}" rel="me"><i class="fab fa-gitlab fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
 	{{ with .Site.Params.social.instagram }}
 	<a href="https://instagram.com/{{.}}" rel="me"><i class="fab fa-instagram fa-lg" aria-hidden="true"></i></a>


### PR DESCRIPTION
This patch allows to specify another gitlab domain name to be used in the links of the social bar.
It can be configured in `[params.social]` section of the config file like:

```toml
[params.social]
  gitlab = "Kerl13"
  custom_gitlab_domain = "gitlab.somewhere.com"
```

By default `gitlab.com` is used (the current behaviour)