### PR TITLE
add include_toc options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ __`Hyde-hyde`__ essentially inherits most of Hyde's [options](https://github.com
   	github = "htr3n"
   	...
   ```
+  
+*  `include_toc = false`: Setting to `false` in FrontMatter will disable too short TOC data as your want. 
 
   * Per PR [#56](https://github.com/htr3n/hyde-hyde/commit/5ed13e17400bbc09a342b60fd50cd9fe3e6f1525), Gravatar pics can be used exclusively to `.Site.Params.authorimage` via the parameter `.Site.Params.social.gravatar`
 

--- a/layouts/partials/page-single/content.html
+++ b/layouts/partials/page-single/content.html
@@ -1,3 +1,4 @@
+{{ $include_toc := .Params.include_toc}}
 <article>
   <header>
     <h1>{{ .Title }}</h1>
@@ -10,15 +11,17 @@
   </header>
   {{ $tableOfContents := .TableOfContents }}
   {{ with .Site.Params.toc }}
-  <div class="toc-wrapper">
-    <input type="checkbox" id="tocToggle">
-    <label for="tocToggle">Table of Content</label>
-    {{ if eq . "hugo" }}
-        {{ $tableOfContents }}
-    {{ else if eq . "tocbot"}}
-      <div class="toc" id="TableOfContents"></div>
-    {{ end }}
-  </div>
+  {{ if ne $include_toc false }}
+    <div class="toc-wrapper">
+      <input type="checkbox" id="tocToggle">
+      <label for="tocToggle">Table of Content</label>
+      {{ if eq . "hugo" }}
+          {{ $tableOfContents }}
+      {{ else if eq . "tocbot"}}
+        <div class="toc" id="TableOfContents"></div>
+      {{ end }}
+    </div>
+  {{ end }}
   {{ end }}
   <div class="post">
     {{ .Content }}

--- a/layouts/partials/page-single/footer.html
+++ b/layouts/partials/page-single/footer.html
@@ -1,3 +1,4 @@
+{{ $include_toc := .Params.include_toc}}
 {{ if .Site.GoogleAnalytics }}
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics_async.html" . }}
@@ -5,8 +6,8 @@
 {{ partial "footer/font-awesome-js.html" . }}
 {{ partial "highlight-js.html" . }}
 {{ with .Site.Params.toc }}
-{{ if eq . "tocbot" }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.4.2/tocbot.js"></script>
+{{ if and (eq . "tocbot") (ne $include_toc false) }}
+<script src="/js/tocbot.js"></script>
 <script type="text/javascript">
   if (tocbot) {
     tocbot.init({

--- a/layouts/partials/page-single/footer.html
+++ b/layouts/partials/page-single/footer.html
@@ -7,7 +7,7 @@
 {{ partial "highlight-js.html" . }}
 {{ with .Site.Params.toc }}
 {{ if and (eq . "tocbot") (ne $include_toc false) }}
-<script src="/js/tocbot.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.4.2/tocbot.js"></script>
 <script type="text/javascript">
   if (tocbot) {
     tocbot.init({


### PR DESCRIPTION
`include_toc = false`: Setting to `false` in FrontMatter will disable too short TOC data as your want. 

```
---
title: "I dot not want TOC in this page"
include_toc: false
---
```