### PR TITLE
Stop using deprecated .RSSLink

### DIFF
--- a/layouts/partials/header/feeds.html
+++ b/layouts/partials/header/feeds.html
@@ -1,5 +1,3 @@
-{{ if .RSSLink }}
-<!-- RSS -->
-<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-{{ end }}
+{{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}


### PR DESCRIPTION
This fixes the deprecation notice: `Page's .RSSLink is deprecated and will be removed in a future release.`

I adjusted the template to the referenced in the hugo docs: https://gohugo.io/templates/rss/#reference-your-rss-feed-in-head