### PR TITLE
Convert deprecated .Hugo to hugo function

### DIFF
--- a/layouts/partials/header/meta.html
+++ b/layouts/partials/header/meta.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Cache-Control" content="public" />
 {{ "<!-- Enable responsiveness on mobile devices -->" | safeHTML }}
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 {{ if .IsHome }}
     {{ $.Scratch.Set "theTitle" .Site.Title }}
 {{else}}


### PR DESCRIPTION
Fixes deprecation message:
> Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.