### PR TITLE
Adjusted post list for Hugo v0.57.0

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
 
 {{ define "content" }}
   <div class="post-list">
-    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "posts") }}
+    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" site.Params.mainSections) }}
     {{ range $paginator.Pages }}
       {{ if .Draft }}
         {{ .Scratch.Set "draftPage" true }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
 
 {{ define "content" }}
   <div class="post-list">
-    {{ $paginator := .Paginate (where .Data.Pages "Type" "posts") }}
+    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "posts") }}
     {{ range $paginator.Pages }}
       {{ if .Draft }}
         {{ .Scratch.Set "draftPage" true }}


### PR DESCRIPTION
# What
Adjusting the index page to show all the posts in descending order in the version [v0.57.0](https://github.com/gohugoio/hugo/releases/tag/v0.57.0) of Hugo.

# Why
After the changes in gohugoio/hugo#6181 included in the version v0.57.0 of Hugo the index page shows the post category instead of all the posts.

*This use of `.Site.RegularPages` keeps retro-compatibility with previous versions of Hugo.*