### PR TITLE
[scss] fix spacing issue in portfolio

### DIFF
--- a/assets/scss/hyde-hyde/_project.scss
+++ b/assets/scss/hyde-hyde/_project.scss
@@ -54,7 +54,7 @@
   margin-bottom: 3.5rem;
 }
 .row-space {
-  margin-bottom: 1rem;
+  margin-bottom: 3rem;
 }
 
 // only needs some pieces from Bootstrap


### PR DESCRIPTION
`row-space.margin-bottom` increased to `3rem` from `1rem` to account for (if any) un-uniformly sized pictures to align correctly.

Master Branch:
https://gist.githubusercontent.com/jkotra/60a4ae0efea623b952cea31dcc826e8c/raw/9032b9b76e94d4e3064ea4618fa2bc2040cb15ed/orig.png

This PR:
https://gist.githubusercontent.com/jkotra/60a4ae0efea623b952cea31dcc826e8c/raw/9032b9b76e94d4e3064ea4618fa2bc2040cb15ed/pr.png