### PR TITLE
Portfolio: load project screenshot only if defined

### DIFF
--- a/layouts/partials/portfolio/content.html
+++ b/layouts/partials/portfolio/content.html
@@ -14,7 +14,9 @@
                             <sup><i class="fa fa-quote-right" aria-hidden="true"></i></sup>
                         </p>
                         <div class="project__featured-image">
-                            <img src="{{ .Params.screenshot }}"  alt="{{ .Title }}">
+                            {{ if .Params.screenshot }}
+                                <img src="{{ .Params.screenshot }}"  alt="{{ .Title }}">
+                            {{ end }}
                         </div>
                         <div class="project__summary">
                                 {{ .Content }}
@@ -31,7 +33,9 @@
             <div class="row">
                 <div class="col-md-4 col-sm-4 col-xs-12" href="{{ .Params.link }}"
                     target="_blank" rel="noopener noreferrer">
-                    <img class="project__image img-responsive" src="{{ .Params.screenshot }}" alt="{{ .Title }}">
+                    {{ if .Params.screenshot }}
+                        <img class="project__image img-responsive" src="{{ .Params.screenshot }}" alt="{{ .Title }}">
+                    {{ end }}
                 </div>
                 <div class="col-md-8 col-sm-8 col-xs-12">
                     <span class="project__title">


### PR DESCRIPTION
# Description
In this way, screenshot becomes optional for a project. I.e. you can omit "screenshot: dera.png" in the front matter.

# Screenshots
This is how it looks like when a screenshot is not defined in the front matter for a project before and after this commit.

## Before
![2019-11-07_713x934](https://user-images.githubusercontent.com/11428655/68419028-c2520280-0199-11ea-8dd7-8996c74844e8.png)

## After
![2019-11-07_748x934](https://user-images.githubusercontent.com/11428655/68419037-c8e07a00-0199-11ea-8a27-adf1704eda63.png)

# Edit
It's the first time I play with hugo, so feel free to adjust the code.

