### PR TITLE
Added Mastodon integration to social sidebar.

### DIFF
--- a/layouts/partials/sidebar/social.html
+++ b/layouts/partials/sidebar/social.html
@@ -45,4 +45,7 @@
 	{{ with .Site.Params.social.email }}
 	<a href="mailto:{{.}}" rel="me"><i class="fas fa-at fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
+	{{ with .Site.Params.social.mastodon }}
+	<a href="{{.}}" rel="me"><i class="fab fa-mastodon fa-lg" aria-hidden="true"></i></a>
+	{{ end }}
 </section>


### PR DESCRIPTION
Added option for [Mastodon](https://joinmastodon.org/) account to be shown in sidebar's social area.

Mastodon accounts can be from any domain rather than just one, so the param is a full URL (like https://mastodon.social/@Gargron).

I have an example of this working at a new blog I set up: https://eatingbrb.gitlab.io