### PR TITLE
Make custom code for body & footer possible

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}">
     {{ block "header" . }}{{ end }}
     <body class="{{ .Site.Params.themeColor }} {{if .Site.Params.layoutReverse}}layout-reverse{{end}}">
+    {{ partial "body/custom.html" . }}
     {{ partial "sidebar.html" . }}
         <div class="content container">
             {{ block "content" . }}{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,9 +36,5 @@
 {{ end }}
 
 {{ define "footer" }}
-  {{ if .Site.GoogleAnalytics }}
-    <!-- Google Analytics -->
-    {{ template "_internal/google_analytics_async.html" . }}
-  {{ end }}
-  {{ partial "footer/font-awesome-js.html" . }}
+  {{ partial "footer.html" . }}
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,6 @@
+{{ if .Site.GoogleAnalytics }}
+	<!-- Google Analytics -->
+	{{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
+{{ partial "footer/font-awesome-js.html" . }}
+{{ partial "footer/custom.html" . }}

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,2 +1,0 @@
-{{ partial "footer/font-awesome-js.html" . }}
-{{ partial "footer/custom.html" . }}

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,0 +1,2 @@
+{{ partial "footer/font-awesome-js.html" . }}
+{{ partial "footer/custom.html" . }}

--- a/layouts/partials/page-list/footer.html
+++ b/layouts/partials/page-list/footer.html
@@ -2,4 +2,3 @@
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
-{{ partial "footer/footer.html" . }}

--- a/layouts/partials/page-list/footer.html
+++ b/layouts/partials/page-list/footer.html
@@ -1,4 +1,1 @@
-{{ if .Site.GoogleAnalytics }}
-  <!-- Google Analytics -->
-  {{ template "_internal/google_analytics_async.html" . }}
-{{ end }}
+{{ partial "footer.html" . }}

--- a/layouts/partials/page-list/footer.html
+++ b/layouts/partials/page-list/footer.html
@@ -2,4 +2,4 @@
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
-{{ partial "footer/font-awesome-js.html" . }}
+{{ partial "footer/footer.html" . }}

--- a/layouts/partials/page-single/footer.html
+++ b/layouts/partials/page-single/footer.html
@@ -3,7 +3,6 @@
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
-{{ partial "footer/footer.html" . }}
 {{ partial "highlight-js.html" . }}
 {{ with .Site.Params.toc }}
 {{ if and (eq . "tocbot") (ne $include_toc false) }}

--- a/layouts/partials/page-single/footer.html
+++ b/layouts/partials/page-single/footer.html
@@ -1,8 +1,6 @@
+{{ partial "footer.html" . }}
+
 {{ $include_toc := .Params.include_toc}}
-{{ if .Site.GoogleAnalytics }}
-  <!-- Google Analytics -->
-  {{ template "_internal/google_analytics_async.html" . }}
-{{ end }}
 {{ partial "highlight-js.html" . }}
 {{ with .Site.Params.toc }}
 {{ if and (eq . "tocbot") (ne $include_toc false) }}

--- a/layouts/partials/page-single/footer.html
+++ b/layouts/partials/page-single/footer.html
@@ -3,7 +3,7 @@
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
-{{ partial "footer/font-awesome-js.html" . }}
+{{ partial "footer/footer.html" . }}
 {{ partial "highlight-js.html" . }}
 {{ with .Site.Params.toc }}
 {{ if and (eq . "tocbot") (ne $include_toc false) }}

--- a/layouts/partials/portfolio/footer.html
+++ b/layouts/partials/portfolio/footer.html
@@ -2,4 +2,3 @@
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
-{{ partial "footer/footer.html" . }}

--- a/layouts/partials/portfolio/footer.html
+++ b/layouts/partials/portfolio/footer.html
@@ -1,4 +1,1 @@
-{{ if .Site.GoogleAnalytics }}
-  <!-- Google Analytics -->
-  {{ template "_internal/google_analytics_async.html" . }}
-{{ end }}
+{{ partial "footer.html" . }}

--- a/layouts/partials/portfolio/footer.html
+++ b/layouts/partials/portfolio/footer.html
@@ -2,4 +2,4 @@
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
-{{ partial "footer/font-awesome-js.html" . }}
+{{ partial "footer/footer.html" . }}


### PR DESCRIPTION
To easily extend the theme with additional javascript in the footer, I propose to add a custom footer/custom.html partial (while the header can still be used to add custom css).
Also, some of the footer code for different templates could be unified.
In rare cases, one could also want to integrate custom body html (I used it in a first attempt to integrate a gallery-feature for images).