### PR TITLE
remove Cache-Control meta header

### DIFF
--- a/layouts/partials/header/meta.html
+++ b/layouts/partials/header/meta.html
@@ -1,6 +1,5 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Cache-Control" content="public" />
 {{ "<!-- Enable responsiveness on mobile devices -->" | safeHTML }}
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 {{ hugo.Generator }}


### PR DESCRIPTION
Per standard, "Cache-Control" is not a valid http-equiv keyword.
https://html.spec.whatwg.org/multipage/semantics.html#pragma-directives

W3C validator marks the corresponding lines as invalid HTML.