### PR TITLE
Add canonical URL link in header.html

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,10 @@
 <head>
     <link href="https://gmpg.org/xfn/11" rel="profile">
+    {{ if .Params.canonicalUrl }}
+    <link rel="canonical" href="{{ .Params.canonicalUrl }}">
+    {{ else }}
+    <link rel="canonical" href="{{ .Permalink }}">
+    {{ end }}
     {{ partial "header/meta.html" . }}
     {{ partial "header/styles.html" . }}
     {{ `<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->


### PR DESCRIPTION
By default the page permalink is used, if necessary a custom `canonicalUrl` parameter can be set in a page front matter.

The canonical URL link is often used to handle "duplicated" pages in the same website or even when the same content is posted in multiple website.