### PR TITLE
Added hackthebox.eu to social sidebar HTML

### DIFF
--- a/layouts/partials/sidebar/social.html
+++ b/layouts/partials/sidebar/social.html
@@ -2,6 +2,10 @@
 	{{ with .Site.Params.social.twitter }}
 	<a href="https://twitter.com/{{.}}" rel="me"><i class="fab fa-twitter fa-lg" aria-hidden="true"></i></a>
 	{{ end }}
+	{{ with .Site.Params.social.hackthebox }}
+	<a href="https://www.hackthebox.eu/home/users/profile/{{.}}" rel="me"><i class="fas fa-cube" aria-hidden="true"></i></a>
+	{{ end }}
+	{{ with .Site.Para
 	{{ with .Site.Params.social.microblog }}
 	<a href="https://micro.blog/{{.}}" rel="me"><i class="fab fa-microblog fa-lg" aria-hidden="true"></i></a>
 	{{ end }}

--- a/layouts/partials/sidebar/social.html
+++ b/layouts/partials/sidebar/social.html
@@ -5,7 +5,6 @@
 	{{ with .Site.Params.social.hackthebox }}
 	<a href="https://www.hackthebox.eu/home/users/profile/{{.}}" rel="me"><i class="fas fa-cube" aria-hidden="true"></i></a>
 	{{ end }}
-	{{ with .Site.Para
 	{{ with .Site.Params.social.microblog }}
 	<a href="https://micro.blog/{{.}}" rel="me"><i class="fab fa-microblog fa-lg" aria-hidden="true"></i></a>
 	{{ end }}


### PR DESCRIPTION
Chose to use the "fas fa-cube" icon since I saw it used elsewhere for the same purpose. 
This uses a similar Param as all other socials:
[params.social]
hackthebox = # profile_id from: https://www.hackthebox.eu/home/users/profile/{profile_id}

Apologies for any breaks in typical process, this is my first pull request :) 