### PR TITLE
Show site title and logo with setting showTitleWithLogo

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -8,6 +8,9 @@
         {{ $strippedSlash := ($.Site.Params.logoimage | replaceRE "^(/)+(.*)" "$2") }}
         {{ $logoImage := (printf "%s%s" $.Site.BaseURL $strippedSlash) }}
           <img src="{{$logoImage}}" alt="Logo Image" class="element--center">
+          {{with $.Site.Params.showTitleWithLogo}} 
+            {{ $.Site.Title }} 
+          {{end}}           
         {{ else }}
           {{ .Site.Title }}
         {{ end }}


### PR DESCRIPTION
In config.toml

````toml
showTitleWithLogo = true
````

And the site title can now be shown underneath the logo.

Example when turned on.
![image](https://user-images.githubusercontent.com/6847665/165924847-bc0aeb5a-8b24-41d9-9bf1-244c5339e543.png)
