### PR TITLE
Fix Hugo deprecations

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,7 +36,7 @@
 {{ end }}
 
 {{ define "footer" }}
-  {{ if .Site.GoogleAnalytics }}
+  {{ if .Site.Config.Services.GoogleAnalytics.ID }}
     <!-- Google Analytics -->
     {{ template "_internal/google_analytics.html" . }}
   {{ end }}

--- a/layouts/partials/page-list/footer.html
+++ b/layouts/partials/page-list/footer.html
@@ -1,4 +1,4 @@
-{{ if .Site.GoogleAnalytics }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics.html" . }}
 {{ end }}

--- a/layouts/partials/page-single/comment/disqus.html
+++ b/layouts/partials/page-single/comment/disqus.html
@@ -13,7 +13,7 @@
     var dsq = document.createElement('script');
     dsq.type = 'text/javascript';
     dsq.async = true;
-    var disqus_shortname = '{{ .Site.DisqusShortname }}';
+    var disqus_shortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
     dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
     (document.getElementsByTagName('head')[0] || 
       document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/layouts/partials/page-single/footer.html
+++ b/layouts/partials/page-single/footer.html
@@ -1,5 +1,5 @@
 {{ $include_toc := .Params.include_toc}}
-{{ if .Site.GoogleAnalytics }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics.html" . }}
 {{ end }}

--- a/layouts/partials/page-single/post-comment.html
+++ b/layouts/partials/page-single/post-comment.html
@@ -1,5 +1,5 @@
 {{ if ne .Params.showcomments false }}
-    {{ if .Site.DisqusShortname }}
+    {{ if .Site.Config.Services.Disqus.Shortname }}
         {{ partial "page-single/comment/disqus.html" . }}
     {{ else if .Site.Params.GraphCommentId }}
         {{ partial "page-single/comment/graphcomment.html" . }}

--- a/layouts/partials/portfolio/footer.html
+++ b/layouts/partials/portfolio/footer.html
@@ -1,4 +1,4 @@
-{{ if .Site.GoogleAnalytics }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
   <!-- Google Analytics -->
   {{ template "_internal/google_analytics.html" . }}
 {{ end }}


### PR DESCRIPTION
Fixes
[ERROR]   stderr) ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.137.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.
[ERROR]   stderr) ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.137.0. Use .Site.Config.Services.Disqus.Shortname instead.